### PR TITLE
Don't attempt an old-school delete when executing a destructive action

### DIFF
--- a/Source/SwipeCollectionViewCell+Accessibility.swift
+++ b/Source/SwipeCollectionViewCell+Accessibility.swift
@@ -71,10 +71,6 @@ extension SwipeCollectionViewCell {
         
         swipeAction.handler?(swipeAction, accessibilityCustomAction.indexPath)
         
-        if swipeAction.style == .destructive {
-            collectionView.deleteItems(at: [accessibilityCustomAction.indexPath])
-        }
-        
         return true
     }
 }


### PR DESCRIPTION
The code presumes that the `UICollectionView` is using the "old school" version of data sources, where calling `delete` on the items would work. It does not if you are using modern diffable data sources, and there is no need for this code to get itself involved in manipulating the collection view. The action itself is responsible for updating the data source such that the cell will no longer be displayed.
This was causing a crash when using the accessibility action version of a destructive swipe action, and given that we only ever use this view with diffable data sources, it feels like a safe change to make for our own code base.